### PR TITLE
openssl-devel パッケージをインストールする形にしました。

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,7 +981,7 @@ dependencies:
       <p>Ruby のコンパイルに必要なものをインストール</p> 
 
 <div><pre><code>$ <span class="console-input">sudo rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm</span>
-$ <span class="console-input">sudo yum -y install git gcc gcc-c++ make patch readline-devel zlib-devel libyaml-devel</span>
+$ <span class="console-input">sudo yum -y install git gcc gcc-c++ make patch readline-devel zlib-devel libyaml-devel openssl-devel</span>
 </code></pre></div>
 
       <p>ruby-build を git clone する</p> 


### PR DESCRIPTION
# index.html 更新

`openssl-devel` パッケージをインストールしないと
ruby-buildを利用してrubyをビルドできないようなので追加しました。

ご確認お願いします。
