### PR TITLE
公式ドキュメントへのリンクを www.ansibleworks.com/docs/ から docs.ansible.com/ に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@ PLAY RECAP ********************************************************************
         <h1><a name="best-practices" class="anchor" href="#best-practices"></a>6. Best Plactices に沿った構成を真似る</h1>
       </div>
 
-      <p><a href="http://www.ansibleworks.com/docs/bestpractices.html">Best Practices</a> のディレクトリ構成にならって WordPress サーバーを構築する Playbook を作成します。 ここは長くなりそうだから詳細は別ページにしよう
+      <p><a href="http://docs.ansible.com/playbooks_best_practices.html">Best Practices</a> のディレクトリ構成にならって WordPress サーバーを構築する Playbook を作成します。 ここは長くなりそうだから詳細は別ページにしよう
       </p>
 
       <p>こんなディレクトリ構成で進めます。<a href="https://github.com/yteraoka/ansible-tutorial/tree/playbook">playbook branch</a> のファイルで一応動作すると思います。随時改善していきます。 このファイルは GitHub <a href="https://github.com/yteraoka/ansible-tutorial.git">https://github.com/yteraoka/ansible-tutorial.git</a> にあります
@@ -831,13 +831,13 @@ Please enter MySQL wordpress user password [wordpress]:
         <dt>roles/</dt>
         <dd style="margin-left: 2em">このディレクトリの下に role (役割) 毎のディレクトリを作成し、それぞれの role にさらに <code>files/</code>, <code>handlers/</code>, <code>tasks/</code>, <code>templates/</code>, <code>vars/</code>, <code>defaults/</code>, <code>meta/</code> というサブディレクトリを作成します (その role で使うもののみ)</dd>
         <dt>roles/*/files/</dt>
-        <dd style="margin-left: 2em">当該 role の task で使うファイル関連モジュール (<a href="http://www.ansibleworks.com/docs/modules.html#copy">copy</a>) が src として使うファイルの置き場所。任意のファイル名で置きます</dd>
+        <dd style="margin-left: 2em">当該 role の task で使うファイル関連モジュール (<a href="http://docs.ansible.com/copy_module.html">copy</a>) が src として使うファイルの置き場所。任意のファイル名で置きます</dd>
         <dt>roles/*/handlers/</dt>
         <dd style="margin-left: 2em">設定変更後にサービスの再起動をさせたりする場合に、notify という定義で処理を呼び出しますが、その呼び出されるハンドラをここで定義します。main.yml というファイルで作成しますが、<code>include</code> という定義で複数ファイルをそこから読み込ませることが可能です</dd>
         <dt>roles/*/tasks/</dt>
         <dd style="margin-left: 2em">何かをインストールしたり、ユーザーを作成したりする task 定義のファイルをここに置きます。handlers と同じように main.yml というファイルが起点となります</dd>
         <dt>roles/*/templates/</dt>
-        <dd style="margin-left: 2em"><a href="http://www.ansibleworks.com/docs/modules.html#template">template</a> モジュールで利用するテンプレートファイルを置きます。このモジュールでは <a href="http://jinja.pocoo.org/docs/">Jinja2</a> (神社) というテンプレートエンジンが使われていて .j2 という拡張子を使います</dd>
+        <dd style="margin-left: 2em"><a href="http://docs.ansible.com/template_module.html">template</a> モジュールで利用するテンプレートファイルを置きます。このモジュールでは <a href="http://jinja.pocoo.org/docs/">Jinja2</a> (神社) というテンプレートエンジンが使われていて .j2 という拡張子を使います</dd>
         <dt>roles/*/vars/</dt>
         <dd style="margin-left: 2em">role 毎に設定する変数を定義するファイルを置きます。handlers や tasks と同じく main.yml ファイルが起点となります</dd>
         <dt>roles/*/defaults/</dt>


### PR DESCRIPTION
ドキュメントをホストするURLが変わっていたので修正しました。
