### PR TITLE
仮想環境にアクセスするには、ユーザー名と秘密鍵の指定が必要

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@ $ <span class="console-input">echo 'PATH=/opt/python-2.7/bin:$PATH' &gt;&gt; ~/.
 
       <p>ping モジュールで疎通確認してみます</p>
 
-<div><pre><code>$ <span class="console-input">ansible 192.168.33.12 -m ping</span>
+<div><pre><code>$ <span class="console-input">ansible 192.168.33.12 -m ping -u vagrant --private-key ~/.vagrant.d/insecure_private_key</span>
 <span class="console-error">ERROR: Unable to find an inventory file, specify one with -i ?</span></code></pre></div>
 
       <p>おっとエラーです。<code>-i</code> で inventory file を指定せよと言われています。Ansible は<a href="https://github.com/yteraoka/ansible-tutorial/wiki/Inventory-File">インベントリファイル</a>に書かれたホストにしかアクセスしません。デフォルトのインベントリファイルが <code>/etc/ansible/hosts</code> です(<code>ansible.cfg</code>で定義されています)が、コマンドラインオプションの <code>-i</code> で指定できます。</p>
@@ -244,7 +244,7 @@ $ <span class="console-input">echo 'PATH=/opt/python-2.7/bin:$PATH' &gt;&gt; ~/.
 
       <p>今度は <code>-i</code> でインベントリファイルを指定して ping モジュールを実行してみましょう</p>
 
-<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -m ping</span>
+<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -m ping -u vagrant --private-key ~/.vagrant.d/insecure_private_key</span>
 
 paramiko: The authenticity of host '192.168.33.12' can't be established. 
 The ssh-rsa key fingerprint is 80c661a0ec2d1f68d5352986ad417f2c. 
@@ -259,13 +259,13 @@ Are you sure you want to continue connecting (yes/no)?
 
       <p>次はリモートホストで任意のコマンドを実行してみましょう</p>
 
-<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -a 'uname -r'</span>
+<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -a 'uname -r' -u vagrant --private-key ~/.vagrant.d/insecure_private_key</span>
 <span class="console-ok">192.168.33.12 | success | rc=0 &gt;&gt;
 2.6.32-431.el6.x86_64</span></code></pre></div>
 
       <p>ついでに yum モジュールでパッケージのインストールも試してみましょう</p>
 
-<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -m yum -s -a name=telnet</span>
+<div><pre><code>$ <span class="console-input">ansible -i hosts 192.168.33.12 -m yum -s -a name=telnet -u vagrant --private-key ~/.vagrant.d/insecure_private_key</span>
 <span class="console-ok">192.168.33.12 | success &gt;&gt; {
     "changed": true, 
     "msg": "warning: rpmts_HdrFromFdno: Header V3 RSA/SHA1 Signature, key ID c105b9de: NOKEY\nImporting GPG key 0xC105B9DE:\n Userid : CentOS-6 Key (CentOS 6 Official Signing Key) &lt;centos-6-key@centos.org&gt;\n Package: centos-release-6-5.el6.centos.11.1.x86_64 (@anaconda-CentOS-201311272149.x86_64/6.5)\n From   : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6\n", 
@@ -422,7 +422,7 @@ PLAY RECAP ********************************************************************
 
       <p>実行結果に「GATHERING FACTS」と出力されています。このような task は playbook に書いていません。これは何でしょう？名前のとおりですが、これは対象サーバーから情報を収集する処理です。次のようにして内容を確認すことができます。</p>
 
-<div><pre style="height: 30em; overflow: scroll"><code>$ <span class="console-input">ansible -m setup -i hosts 192.168.33.12</span>
+<div><pre style="height: 30em; overflow: scroll"><code>$ <span class="console-input">ansible -m setup -i hosts 192.168.33.12 -u vagrant --private-key ~/.vagrant.d/insecure_private_key</span>
 <span class="console-ok">192.168.33.12 | success >> {
     "ansible_facts": {
         "ansible_all_ipv4_addresses": [


### PR DESCRIPTION
仮想環境に ssh 接続しようとするときに、ユーザー名はローカルユーザー名で
秘密鍵については ${HOME}/.ssh/id_rsa を見にいってしまい ssh 接続できませんでした。

そこで、ユーザー名と秘密鍵を指定して、ssh 接続するように ansible コマンドに オプションを追加しました。
